### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -5,7 +5,7 @@ var
 	http    = require('http'),
 	P       = require('p-promise'),
 	restify = require('restify'),
-	uuid    = require('node-uuid'),
+	uuid    = require('uuid'),
 	muxer   = require('./keymuxer')
 	;
 

--- a/lib/mesh.js
+++ b/lib/mesh.js
@@ -14,7 +14,7 @@ var
 	RemoteNode = require('./remotenode'),
 	net        = require('net'),
 	P          = require('p-promise'),
-	uuid       = require('node-uuid')
+	uuid       = require('uuid')
 	;
 
 function Mesh(opts)

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "light-cycle": "~1.3.2",
     "lodash": "~3.10.1",
     "my-local-ip": "*",
-    "node-uuid": "*",
     "p-promise": "~0.5.0",
     "restify": "~4.0.3",
     "scuttlebutt": "~5.6.8",
+    "uuid": "^3.0.0",
     "yargs": "~4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.